### PR TITLE
Generate unit conversion data from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 .idea
 /target
 **/dist
-**/default_currencies.rs
 .env
 **.wixobj
 **.wixpdb
 **.msi
 **.dmg
+
+# generated files
+**/default_currencies.rs
+**/unit_conversion.rs

--- a/calculator/build.rs
+++ b/calculator/build.rs
@@ -5,8 +5,10 @@
  */
 
 use std::collections::HashMap;
+use std::fs;
 
 const OUTPUT_FILE: &str = "src/environment/default_currencies.rs";
+const UNITS_OUTPUT_FILE: &str = "src/environment/unit_conversion.rs";
 
 #[derive(serde::Deserialize, Debug)]
 struct ApiResponse {
@@ -14,7 +16,25 @@ struct ApiResponse {
     rates: HashMap<String, serde_json::Value>,
 }
 
-fn main() -> reqwest::Result<()> {
+fn update_units_file() -> Result<(), Box<dyn std::error::Error>> {
+    let src_file_modified = fs::metadata("unit_data.txt")
+        .ok()
+        .and_then(|meta| meta.modified().ok());
+    let output_file_modified = fs::metadata(UNITS_OUTPUT_FILE)
+        .ok()
+        .and_then(|meta| meta.modified().ok());
+
+    if std::path::PathBuf::from(UNITS_OUTPUT_FILE).try_exists().unwrap_or(false)
+        && src_file_modified == output_file_modified { return Ok(()); }
+
+    let source = fs::read_to_string("unit_data.txt")?;
+    let mut generator = unit_data::Generator::new(source, UNITS_OUTPUT_FILE.into());
+    generator.generate()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    update_units_file()?;
+
     if &std::env::var("PROFILE").unwrap_or_default() != "release" &&
         std::path::PathBuf::from(OUTPUT_FILE).try_exists().unwrap_or(false) {
         return Ok(());
@@ -25,7 +45,9 @@ fn main() -> reqwest::Result<()> {
             .json::<ApiResponse>()?;
 
     let mut output = String::new();
-    output += r#"use phf::{Map, phf_map};
+    output += r#"// this file is generated in build.rs. Make changes there!
+
+use phf::{Map, phf_map};
 
 pub const BASE_CURRENCY: &str = ""#;
     output += &base;
@@ -51,6 +73,421 @@ pub static CURRENCIES: Map<&'static str, f64> = phf_map! {"#;
     output += r#"
 };"#;
 
-    std::fs::write(OUTPUT_FILE, output).expect("Could not write to file");
+    fs::write(OUTPUT_FILE, output).expect("Could not write to file");
     Ok(())
+}
+
+mod unit_data {
+    use std::fmt::{Debug, Display, Formatter};
+    use std::fs;
+
+    const MODIFIER_NORMAL: char = 'n';
+    const MODIFIER_POWER: char = 'p';
+
+    #[derive(Debug)]
+    struct Unit {
+        abbreviation: String,
+        name: String,
+        plural_name: String,
+    }
+
+    impl Unit {
+        fn new(abbreviation: String, name: String, plural_name: Option<String>) -> Self {
+            let plural_name = plural_name.unwrap_or_else(|| {
+                let mut name = name.clone();
+                name.push('s');
+                name
+            });
+            Self {
+                abbreviation,
+                name,
+                plural_name,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct Conversion {
+        src: String,
+        dst: String,
+        src_to_dst_expr: String,
+        dst_to_src_expr: Option<String>,
+        modifiers: Vec<char>,
+    }
+
+    impl Conversion {
+        fn new(
+            src: String,
+            dst: String,
+            std_expr: String,
+            dts_expr: Option<String>,
+            modifiers: String,
+        ) -> Self {
+            Self {
+                src,
+                dst,
+                src_to_dst_expr: std_expr,
+                dst_to_src_expr: dts_expr,
+                modifiers: modifiers.chars().collect::<Vec<_>>(),
+            }
+        }
+
+        fn generate_lines(&self) -> Vec<String> {
+            let mut result = Vec::new();
+
+            result.push(format!("\t\t(\"{}\", \"{}\") => Ok({}),", self.src, self.dst, self.src_to_dst_expr));
+            if let Some(dts_expr) = &self.dst_to_src_expr {
+                result.push(format!("\t\t(\"{}\", \"{}\") => Ok({}),", self.dst, self.src, dts_expr));
+            }
+
+            fn invert_operator(op: char) -> char {
+                match op {
+                    '*' => '/',
+                    '/' => '*',
+                    '+' => '-',
+                    '-' => '+',
+                    _ => op,
+                }
+            }
+
+            for modifier in &self.modifiers {
+                match *modifier {
+                    MODIFIER_NORMAL => 'blk: {
+                        if self.dst_to_src_expr.is_some() { break 'blk; }
+
+                        let mut parts = self.src_to_dst_expr.split(' ');
+                        let mut dts_expr = parts.next().unwrap().to_string();
+                        let new_operator = invert_operator(parts.next().unwrap().chars().next().unwrap());
+                        dts_expr += &format!(" {} ", new_operator);
+                        dts_expr += &parts.collect::<Vec<_>>().join(" ");
+                        result.push(format!("\t\t(\"{}\", \"{}\") => Ok({}),", self.dst, self.src, dts_expr));
+                    }
+                    MODIFIER_POWER => {
+                        let mut parts = self.src_to_dst_expr.split(' ');
+                        let start = parts.next().unwrap().to_string();
+                        let operator = parts.next().unwrap().chars().next().unwrap();
+
+                        let number = parts.next().unwrap().parse::<f64>().unwrap();
+
+                        for exponent in 2..=3 {
+                            let number_powered = number.powi(exponent);
+                            let mut powered = number_powered.to_string();
+                            if number_powered.fract() == 0.0 { powered += ".0"; }
+
+                            result.push(format!(
+                                "\t\t(\"{}^{exponent}\", \"{}^{exponent}\") => Ok({start} {operator} {powered}),",
+                                self.src,
+                                self.dst,
+                            ));
+
+                            if self.modifiers.contains(&MODIFIER_NORMAL) {
+                                result.push(format!(
+                                    "\t\t(\"{}^{exponent}\", \"{}^{exponent}\") => Ok({start} {} {powered}),",
+                                    self.dst,
+                                    self.src,
+                                    invert_operator(operator),
+                                ));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            result
+        }
+    }
+
+    pub struct Generator {
+        source: Vec<String>,
+        index: usize,
+        lines: usize,
+        output_file_path: String,
+
+        units: Vec<Unit>,
+        conversions: Vec<Conversion>,
+    }
+
+    macro_rules! next_or_err {
+    ($iter:expr, $curr_idx:expr) => {
+        if let Some(v) = $iter.next() {
+            v
+        }
+        else { return Err(Error($curr_idx).into()) }
+    }
+}
+
+    impl Generator {
+        pub fn new(source: String, output_file_path: String) -> Self {
+            Self {
+                source: source.lines().map(|s| s.to_string()).collect::<Vec<String>>(),
+                output_file_path,
+                index: 0,
+                lines: source.lines().count(),
+                units: Vec::new(),
+                conversions: Vec::new(),
+            }
+        }
+
+        pub fn generate(&mut self) -> std::result::Result<(), Box<dyn std::error::Error>> {
+            self.parse_units()?;
+
+            while self.index != self.lines {
+                let line = self.source[self.index].trim();
+                if line.is_empty() || line.starts_with('#') {
+                    self.index += 1;
+                    continue;
+                }
+
+                let mut parts = line.split([':', '|']);
+                let (src, dst) = self.parse_conversion_head(
+                    parts.next().unwrap_or_default()
+                )?;
+
+                let expressions = next_or_err!(parts, self.index).trim().to_string();
+                if expressions.is_empty() { return Err(Error(self.index).into()); }
+
+                let std_expr: String;
+                let mut dts_expr: Option<String> = None;
+                if let Some(semicolon_idx) = expressions.find(';') {
+                    std_expr = expressions[0..semicolon_idx].trim().to_string();
+                    let _dts_expr = expressions[semicolon_idx + 1..].trim().to_string();
+                    if std_expr.is_empty() || _dts_expr.is_empty() { return Err(Error(self.index).into()); }
+                    dts_expr = Some(_dts_expr);
+                } else {
+                    std_expr = expressions;
+                }
+
+                let modifiers = parts.next().unwrap_or_default().trim().to_string();
+                if dts_expr.is_some() && !modifiers.is_empty() { return Err(Error(self.index).into()); }
+
+                self.conversions.push(Conversion::new(src, dst, std_expr, dts_expr, modifiers));
+                self.index += 1;
+            }
+
+            self.write_to_file()?;
+
+            Ok(())
+        }
+
+        fn write_to_file(&self) -> std::io::Result<()> {
+            let mut file_content = String::new();
+            file_content += r#"// this file is generated in build.rs. Make changes there!
+
+use std::f64::consts::PI;
+use std::ops::Range;
+use crate::{
+    common::Result,
+    environment::currencies::{Currencies, is_currency},
+    environment::units::{PREFIXES, prefix_to_string, is_unit},
+};
+"#;
+            let unit_strings = self.units.iter()
+                .flat_map(|u| {
+                    // Check if we need to add powers
+                    if self.conversions.iter()
+                        .find(|conv| {
+                            conv.src == u.abbreviation || conv.dst == u.abbreviation
+                        })
+                        .map(|conv| conv.modifiers.contains(&'p'))
+                        .unwrap_or(false) {
+                        let mut result = Vec::new();
+                        result.push(format!("\"{}\"", u.abbreviation));
+
+                        for exponent in 2..=3 {
+                            result.push(format!("\"{}^{}\"", u.abbreviation, exponent));
+                        }
+                        result
+                    } else {
+                        vec![format!("\"{}\"", u.abbreviation)]
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            file_content += &format!("\npub const UNITS: [&str; {}] = [\n", unit_strings.len());
+            file_content += &format!("\t{}", unit_strings.join(", "));
+
+            file_content += "\n];\n";
+
+            file_content += r#"
+fn unit_prefix(unit: &str) -> Option<(char, i32)> {
+    if unit.len() < 2 { return None; }
+    if is_unit(unit) { return None; }
+
+    let char = unit.chars().next().unwrap();
+    PREFIXES.into_iter().find(|&prefix| prefix.0 == char)
+}
+
+pub fn convert_units(src_unit: &str, dst_unit: &str, x: f64, currencies: &Currencies, range: &Range<usize>) -> Result<f64> {
+    if src_unit == dst_unit { return Ok(x); }
+
+    let mut src_unit = src_unit;
+    let mut dst_unit = dst_unit;
+
+    let src_power = unit_prefix(src_unit).map(|x| x.1).unwrap_or(0);
+    if src_power != 0 { src_unit = &src_unit[1..]; }
+    let dst_power = unit_prefix(dst_unit).map(|x| x.1).unwrap_or(0);
+    if dst_power != 0 { dst_unit = &dst_unit[1..]; }
+
+    let x = x * 10f64.powi(src_power - dst_power);
+
+    if src_unit == dst_unit { return Ok(x); }
+
+    match (src_unit, dst_unit) {
+"#;
+
+            file_content += &self.conversions.iter()
+                .flat_map(|c| {
+                    c.generate_lines()
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            file_content += r#"
+        _ => currencies.convert(src_unit, dst_unit, x, range),
+    }
+}
+
+pub fn format_unit(unit: &str, plural: bool) -> String {
+    fn lowercase_first(s: &str) -> String {
+        let mut chars = s.chars();
+        match chars.next() {
+            Some(char) => char.to_lowercase().chain(chars).collect(),
+            None => String::new(),
+        }
+    }
+
+    let prefix = unit_prefix(unit).map(|x| x.0);
+    let unit = if prefix.is_some() { &unit[1..] } else { unit };
+
+    let mut result = String::new();
+
+    if let Some(prefix) = prefix {
+        result += prefix_to_string(prefix).unwrap();
+    }
+
+    if is_currency(unit) {
+        if result.len() - 1 != 0 { result.push(' '); }
+        return result + unit;
+    }
+
+    if plural {
+        let str = match unit {
+"#;
+
+            file_content += &self.format_unit_long_form_match_arms(true);
+            file_content += r#"
+            _ => unreachable!(),
+        };
+
+        if prefix.is_some() { result + &lowercase_first(str) }
+        else { result + str }
+    }
+    else {
+        let str = match unit {
+"#;
+
+            file_content += &self.format_unit_long_form_match_arms(false);
+            file_content += r#"
+            _ => unreachable!(),
+        };
+
+        if prefix.is_some() { result + &lowercase_first(str) }
+        else { result + str }
+    }
+}
+"#;
+
+            fs::write(self.output_file_path.clone(), file_content)?;
+
+            Ok(())
+        }
+
+        fn format_unit_long_form_match_arms(&self, plural: bool) -> String {
+            self.units.iter()
+                .flat_map(|unit| {
+                    let name = if plural { &unit.plural_name } else { &unit.name };
+
+                    if self.conversions.iter()
+                        .find(|conv| {
+                            conv.src == unit.abbreviation || conv.dst == unit.abbreviation
+                        })
+                        .map(|conv| conv.modifiers.contains(&'p'))
+                        .unwrap_or(false) {
+                        vec![
+                            format!("\t\t\t\"{}\" => \"{}\",", unit.abbreviation, name),
+                            format!("\t\t\t\"{}^2\" => \"{} squared\",", unit.abbreviation, name),
+                            format!("\t\t\t\"{}^3\" => \"{} cubed\",", unit.abbreviation, name),
+                        ]
+                    } else {
+                        vec![format!("\t\t\t\"{}\" => \"{}\",", unit.abbreviation, name)]
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+
+        fn parse_conversion_head(&self, s: &str) -> Result<(String, String)> {
+            let mut parts = s.split("->");
+            let src = next_or_err!(parts, self.index);
+            let dst = next_or_err!(parts, self.index);
+
+            Ok((src.into(), dst.into()))
+        }
+
+        fn parse_units(&mut self) -> Result<()> {
+            while self.index != self.lines {
+                let line = self.source[self.index].trim();
+                if line.is_empty() || line.starts_with('#') {
+                    self.index += 1;
+                    continue;
+                } else if line.starts_with("----") {
+                    self.index += 1;
+                    break;
+                }
+
+                let line_parts = line.split(',');
+                for unit in line_parts {
+                    if unit.is_empty() { continue; }
+                    let Some(ci) = unit.find(':') else { return Err(self.index.into()); };
+                    let abb = unit[0..ci].trim().to_string();
+                    let long_forms = unit[ci + 1..].trim().to_string();
+
+                    let singular: String;
+                    let mut plural: Option<String> = None;
+                    if let Some(slash_idx) = long_forms.find('/') {
+                        singular = long_forms[0..slash_idx].trim().to_string();
+                        plural = Some(long_forms[slash_idx + 1..].trim().to_string());
+                    } else {
+                        singular = long_forms;
+                    }
+
+                    self.units.push(Unit::new(abb, singular, plural));
+                }
+
+                self.index += 1;
+            }
+
+            Ok(())
+        }
+    }
+
+    type Result<T> = std::result::Result<T, Error>;
+
+    #[derive(Debug)]
+    struct Error(usize);
+
+    impl From<usize> for Error {
+        fn from(i: usize) -> Self {
+            Self(i)
+        }
+    }
+
+    impl std::error::Error for Error {}
+
+    impl Display for Error {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
 }

--- a/calculator/src/engine.rs
+++ b/calculator/src/engine.rs
@@ -465,7 +465,6 @@ impl<'a> Engine<'a> {
 mod tests {
     use crate::{parse, ParserResult, tokenize};
     use crate::common::Result;
-    use crate::environment::units::format as format_unit;
 
     use super::*;
 
@@ -565,13 +564,13 @@ mod tests {
     fn print_full_unit() -> Result<()> {
         let res = eval!("1min")?;
         assert!(res.is_long_unit);
-        assert_eq!(format_unit(&res.unit.unwrap(), false), " Minute");
+        assert_eq!(res.unit.unwrap().format(false), "Minute");
         let res = eval!("3m")?;
-        assert_eq!(format_unit(&res.unit.unwrap(), true), " Meters");
+        assert_eq!(res.unit.unwrap().format(true), "Meters");
         let res = eval!("3km")?;
-        assert_eq!(format_unit(&res.unit.unwrap(), true), " Kilometers");
+        assert_eq!(res.unit.unwrap().format(true), "Kilometers");
         let res = eval!("3km/h")?;
-        assert_eq!(format_unit(&res.unit.unwrap(), true), " Kilometers per Hour");
+        assert_eq!(res.unit.unwrap().format(true), "Kilometers per Hour");
         Ok(())
     }
 

--- a/calculator/src/environment/mod.rs
+++ b/calculator/src/environment/mod.rs
@@ -17,9 +17,11 @@ use crate::engine::CalculationResult;
 use self::units::Unit;
 
 pub mod units;
-// This file will generated in build.rs at build time
-mod default_currencies;
 pub mod currencies;
+
+// These files are generated in build.rs during build time
+mod default_currencies;
+mod unit_conversion;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Variable(pub f64, pub Option<Unit>);

--- a/calculator/src/environment/units.rs
+++ b/calculator/src/environment/units.rs
@@ -28,7 +28,7 @@ impl Unit {
 
         if let Some(denom) = &self.1 {
             let denom = format_unit(denom, false);
-            result += " per";
+            result += " per ";
             result += &denom;
         }
 

--- a/calculator/src/environment/units.rs
+++ b/calculator/src/environment/units.rs
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::f64::consts::PI;
 use std::ops::Range;
 
 use crate::{
     common::{ErrorType, Result},
     environment::currencies::{Currencies, is_currency},
+    environment::unit_conversion::{convert_units, format_unit, UNITS},
 };
 
 /// A struct representing a unit, holding a numerator and an optional denominator unit.
@@ -19,6 +19,22 @@ use crate::{
 /// - denominator (1): `"h"`
 #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Unit(pub String, pub Option<String>);
+
+impl Unit {
+    pub fn format(&self, plural: bool) -> String {
+        let mut result = String::new();
+        let numerator = format_unit(&self.0, plural);
+        result += &numerator;
+
+        if let Some(denom) = &self.1 {
+            let denom = format_unit(denom, false);
+            result += " per";
+            result += &denom;
+        }
+
+        result
+    }
+}
 
 impl From<&str> for Unit {
     fn from(s: &str) -> Self { Unit(s.to_owned(), None) }
@@ -34,24 +50,26 @@ impl std::fmt::Display for Unit {
     }
 }
 
-const UNITS: [&str; 40] = [
-    "m", "mi", "ft", "in", "yd", // length
-    "a", "m^2", "mi^2", "ft^2", "in^2", "yd^2",  // area
-    "l", "tsp", "tbsp", "floz", "cup", "m^3", "mi^3", "ft^3", "in^3", "yd^3", // volume
-    "°", "rad", // angle
-    "s", "min", "h", "d", "mo", "y", // time
-    "g", "lb", "t", // mass
-    "Pa", "bar", "psi", // pressure
-    "°C", "°F", "K", // temperature
-    "cal", "b", // misc
-];
-
 // Stores prefix with it's power (e.g. k => * 10^3)
-const PREFIXES: [(char, i32); 9] = [
+pub const PREFIXES: [(char, i32); 9] = [
     ('m', -3), ('c', -2), ('d', -1),
     ('\0', 0),
     ('h', 2), ('k', 3), ('M', 6), ('G', 9), ('T', 12)
 ];
+
+pub fn prefix_to_string(prefix: char) -> Option<&'static str> {
+    match prefix {
+        'm' => Some("Milli"),
+        'c' => Some("Centi"),
+        'd' => Some("Deci"),
+        'h' => Some("Hecto"),
+        'k' => Some("Kilo"),
+        'M' => Some("Mega"),
+        'G' => Some("Giga"),
+        'T' => Some("Tera"),
+        _ => None,
+    }
+}
 
 pub fn is_unit(str: &str) -> bool {
     UNITS.contains(&str) || is_currency(str)
@@ -69,14 +87,6 @@ pub fn get_prefix_power(c: char) -> Option<i32> {
         if p == c { return Some(e); }
     }
     None
-}
-
-fn unit_prefix(unit: &str) -> Option<(char, i32)> {
-    if unit.len() < 2 { return None; }
-    if is_unit(unit) { return None; }
-
-    let char = unit.chars().next().unwrap();
-    PREFIXES.into_iter().find(|&prefix| prefix.0 == char)
 }
 
 pub fn convert(src_unit: &Unit, dst_unit: &Unit, n: f64, currencies: &Currencies, range: &Range<usize>) -> Result<f64> {
@@ -97,404 +107,4 @@ pub fn convert(src_unit: &Unit, dst_unit: &Unit, n: f64, currencies: &Currencies
         Err(ErrorType::UnknownConversion(src_unit.to_string(), dst_unit.to_string())
             .with(range.clone()))
     }
-}
-
-fn convert_units(src_unit: &str, dst_unit: &str, n: f64, currencies: &Currencies, range: &Range<usize>) -> Result<f64> {
-    if src_unit == dst_unit { return Ok(n); }
-
-    let mut src_unit = src_unit;
-    let mut dst_unit = dst_unit;
-
-    let src_power = unit_prefix(src_unit).map(|x| x.1).unwrap_or(0);
-    if src_power != 0 { src_unit = &src_unit[1..]; }
-    let dst_power = unit_prefix(dst_unit).map(|x| x.1).unwrap_or(0);
-    if dst_power != 0 { dst_unit = &dst_unit[1..]; }
-
-    let n = n * 10f64.powi(src_power - dst_power);
-
-    if src_unit == dst_unit { return Ok(n); }
-
-    match (src_unit, dst_unit) {
-        // distance
-        ("m", "mi") => Ok(n / 1609.344),
-        ("m", "ft") => Ok(n * 3.281),
-        ("m", "in") => Ok(n * 39.37),
-        ("m", "yd") => Ok(n * 1.094),
-
-        ("ft", "m") => Ok(n / 3.281),
-        ("ft", "mi") => Ok(n / 5280.0),
-        ("ft", "in") => Ok(n * 12.0),
-        ("ft", "yd") => Ok(n / 3.0),
-
-        ("mi", "m") => Ok(n * 1609.344),
-        ("mi", "ft") => Ok(n * 5280.0),
-        ("mi", "in") => Ok(n * 63360.0),
-        ("mi", "yd") => Ok(n * 1760.0),
-
-        ("in", "m") => Ok(n / 39.37),
-        ("in", "ft") => Ok(n / 12.0),
-        ("in", "mi") => Ok(n / 63360.0),
-        ("in", "yd") => Ok(n / 36.0),
-
-        ("yd", "m") => Ok(n * 1.094),
-        ("yd", "ft") => Ok(n * 3.0),
-        ("yd", "mi") => Ok(n / 1760.0),
-        ("yd", "in") => Ok(n * 36.0),
-
-        // area
-        ("m^2", "mi^2") => Ok(n / 2_590_000.0),
-        ("m^2", "ft^2") => Ok(n * 10.764),
-        ("m^2", "in^2") => Ok(n * 1550.0),
-        ("m^2", "yd^2") => Ok(n * 1.196),
-        ("m^2", "a") => Ok(n / 100.0),
-
-        ("ft^2", "m^2") => Ok(n / 10.764),
-        ("ft^2", "mi^2") => Ok(n / 27_880_000.0),
-        ("ft^2", "in^2") => Ok(n * 144.0),
-        ("ft^2", "yd^2") => Ok(n / 9.0),
-        ("ft^2", "a") => Ok(n / 1076.0),
-
-        ("mi^2", "m^2") => Ok(n * 2_590_000.0),
-        ("mi^2", "ft^2") => Ok(n * 27_880_000.0),
-        ("mi^2", "in^2") => Ok(n * 4_014_000_000.0),
-        ("mi^2", "yd^2") => Ok(n * 3_098_000.0),
-        ("mi^2", "a") => Ok(n * 25_900.0),
-
-        ("in^2", "m^2") => Ok(n / 1550.0),
-        ("in^2", "ft^2") => Ok(n / 144.0),
-        ("in^2", "mi^2") => Ok(n / 4_014_000_000.0),
-        ("in^2", "yd^2") => Ok(n / 1296.0),
-        ("in^2", "a") => Ok(n / 155_000.0),
-
-        ("yd^2", "m^2") => Ok(n / 1.196),
-        ("yd^2", "ft^2") => Ok(n * 9.0),
-        ("yd^2", "mi^2") => Ok(n / 3_098_000.0),
-        ("yd^2", "in^2") => Ok(n * 1296.0),
-        ("yd^2", "a") => Ok(n / 119.6),
-
-        ("a", "m^2") => Ok(n * 100.0),
-        ("a", "mi^2") => Ok(n / 25_900.0),
-        ("a", "ft^2") => Ok(n * 1076.0),
-        ("a", "in^2") => Ok(n * 155_000.0),
-        ("a", "yd^2") => Ok(n * 119.6),
-
-        // volume
-        ("l", "tsp") => Ok(n * 202.9),
-        ("l", "tbsp") => Ok(n * 67.628),
-        ("l", "floz") => Ok(n * 33.814),
-        ("l", "cup") => Ok(n * 4.227),
-        ("l", "m^3") => Ok(n / 1000.0),
-        ("l", "mi^3") => Ok(n / 4_168_000_000_000.0),
-        ("l", "ft^3") => Ok(n / 28.317),
-        ("l", "in^3") => Ok(n * 61.024),
-        ("l", "yd^3") => Ok(n / 764.6),
-
-        ("tsp", "l") => Ok(n / 202.9),
-        ("tsp", "tbsp") => Ok(n / 3.0),
-        ("tsp", "floz") => Ok(n / 6.0),
-        ("tsp", "cup") => Ok(n / 48.0),
-        ("tsp", "m^3") => Ok(n / 202_900.0),
-        ("tsp", "mi^3") => Ok(n / 845_700_000_000_000.0),
-        ("tsp", "ft^3") => Ok(n / 5745.0),
-        ("tsp", "in^3") => Ok(n / 3.325),
-        ("tsp", "yd^3") => Ok(n / 155_100.0),
-
-        ("tbsp", "l") => Ok(n / 67.628),
-        ("tbsp", "tsp") => Ok(n * 3.0),
-        ("tbsp", "floz") => Ok(n / 2.0),
-        ("tbsp", "cup") => Ok(n / 16.0),
-        ("tbsp", "m^3") => Ok(n / 67_630.0),
-        ("tbsp", "mi^3") => Ok(n / 281_900_000_000_000.0),
-        ("tbsp", "ft^3") => Ok(n / 1915.0),
-        ("tbsp", "in^3") => Ok(n / 1.108),
-        ("tbsp", "yd^3") => Ok(n / 51_710.0),
-
-        ("floz", "l") => Ok(n / 33.814),
-        ("floz", "tsp") => Ok(n * 6.0),
-        ("floz", "tbsp") => Ok(n * 2.0),
-        ("floz", "cup") => Ok(n / 8.0),
-        ("floz", "m^3") => Ok(n / 284_130.0),
-        ("floz", "mi^3") => Ok(n / 146_700_000_000_000.0),
-        ("floz", "ft^3") => Ok(n / 996.6),
-        ("floz", "in^3") => Ok(n / 1.1734),
-        ("floz", "yd^3") => Ok(n / 25_850.0),
-
-        ("cup", "l") => Ok(n / 4.227),
-        ("cup", "tsp") => Ok(n * 48.0),
-        ("cup", "tbsp") => Ok(n * 16.0),
-        ("cup", "floz") => Ok(n * 8.0),
-        ("cup", "m^3") => Ok(n / 4227.0),
-        ("cup", "mi^3") => Ok(n / 146_700_000_000_000.0),
-        ("cup", "ft^3") => Ok(n / 119.7),
-        ("cup", "in^3") => Ok(n * 14.438),
-        ("cup", "yd^3") => Ok(n / 3232.0),
-
-        ("m^3", "mi^3") => Ok(n / 4_168_000_000.0),
-        ("m^3", "ft^3") => Ok(n * 35.315),
-        ("m^3", "in^3") => Ok(n * 61_020.0),
-        ("m^3", "yd^3") => Ok(n * 1.308),
-        ("m^3", "l") => Ok(n * 1000.0),
-        ("m^3", "tsp") => Ok(n * 202_900.0),
-        ("m^3", "tbsp") => Ok(n * 67_630.0),
-        ("m^3", "floz") => Ok(n * 284_130.0),
-        ("m^3", "cup") => Ok(n * 4227.0),
-
-        ("ft^3", "m^3") => Ok(n / 35.315),
-        ("ft^3", "mi^3") => Ok(n / 147_200_000_000.0),
-        ("ft^3", "in^3") => Ok(n * 1728.0),
-        ("ft^3", "yd^3") => Ok(n / 27.0),
-        ("ft^3", "l") => Ok(n * 28.317),
-        ("ft^3", "tsp") => Ok(n * 5745.0),
-        ("ft^3", "tbsp") => Ok(n * 1915.0),
-        ("ft^3", "cup") => Ok(n * 119.7),
-        ("ft^3", "floz") => Ok(n * 996.6),
-
-        ("mi^3", "m^3") => Ok(n * 4_168_000_000.0),
-        ("mi^3", "ft^3") => Ok(n * 147_200_000_000.0),
-        ("mi^3", "in^3") => Ok(n * 254_400_000_000_000.0),
-        ("mi^3", "yd^3") => Ok(n * 5_452_000_000.0),
-        ("mi^3", "l") => Ok(n * 4_168_000_000_000.0),
-        ("mi^3", "tsp") => Ok(n * 845_700_000_000_000.0),
-        ("mi^3", "tbsp") => Ok(n * 281_900_000_000_000.0),
-        ("mi^3", "floz") => Ok(n * 146_700_000_000_000.0),
-        ("mi^3", "cup") => Ok(n * 146_700_000_000_000.0),
-
-        ("in^3", "m^3") => Ok(n / 61_020.0),
-        ("in^3", "ft^3") => Ok(n / 1728.0),
-        ("in^3", "mi^3") => Ok(n / 254_400_000_000_000.0),
-        ("in^3", "yd^3") => Ok(n / 46_660.0),
-        ("in^3", "l") => Ok(n / 61.024),
-        ("in^3", "tsp") => Ok(n * 3.325),
-        ("in^3", "tbsp") => Ok(n * 1.108),
-        ("in^3", "floz") => Ok(n * 1.1734),
-        ("in^3", "cup") => Ok(n / 14.438),
-
-        ("yd^3", "m^3") => Ok(n / 1.308),
-        ("yd^3", "ft^3") => Ok(n * 27.0),
-        ("yd^3", "mi^3") => Ok(n / 5_452_000_000.0),
-        ("yd^3", "in^3") => Ok(n * 46_660.0),
-        ("yd^3", "l") => Ok(n * 764.6),
-        ("yd^3", "tsp") => Ok(n * 155_100.0),
-        ("yd^3", "tbsp") => Ok(n * 51_710.0),
-        ("yd^3", "floz") => Ok(n * 25_850.0),
-        ("yd^3", "cup") => Ok(n * 3232.0),
-
-        // angle
-        ("°", "rad") => Ok(n * PI / 180.0),
-        ("rad", "°") => Ok(n * 180.0 / PI),
-
-        // time
-        ("s", "min") => Ok(n / 60.0),
-        ("s", "h") => Ok(n / 3600.0),
-        ("s", "d") => Ok(n / 86_400.0),
-        ("s", "mo") => Ok(n / 2_628_000.0),
-        ("s", "y") => Ok(n / 31_540_000.0),
-
-        ("min", "s") => Ok(n * 60.0),
-        ("min", "h") => Ok(n / 60.0),
-        ("min", "d") => Ok(n / 1440.0),
-        ("min", "mo") => Ok(n / 43_800.0),
-        ("min", "y") => Ok(n / 525_600.0),
-
-        ("h", "s") => Ok(n * 3600.0),
-        ("h", "min") => Ok(n * 60.0),
-        ("h", "d") => Ok(n / 24.0),
-        ("h", "mo") => Ok(n / 730.0),
-        ("h", "y") => Ok(n / 8760.0),
-
-        ("d", "s") => Ok(n * 86_400.0),
-        ("d", "min") => Ok(n * 1440.0),
-        ("d", "h") => Ok(n * 24.0),
-        ("d", "mo") => Ok(n / 30.417),
-        ("d", "y") => Ok(n / 365.0),
-
-        ("mo", "s") => Ok(n * 2_628_000.0),
-        ("mo", "min") => Ok(n * 43_800.0),
-        ("mo", "h") => Ok(n * 730.0),
-        ("mo", "d") => Ok(n * 30.417),
-        ("mo", "y") => Ok(n / 12.0),
-
-        ("y", "s") => Ok(n * 31_540_000.0),
-        ("y", "min") => Ok(n * 525_600.0),
-        ("y", "h") => Ok(n * 8760.0),
-        ("y", "d") => Ok(n * 365.0),
-        ("y", "mo") => Ok(n * 12.0),
-
-        // mass
-        ("g", "lb") => Ok(n / 453.59237),
-        ("g", "t") => Ok(n / 1_000_000.0),
-
-        ("lb", "g") => Ok(n * 453.59237),
-        ("lb", "t") => Ok(n / 2205.0),
-
-        ("t", "g") => Ok(n * 1_000_000.0),
-        ("t", "lb") => Ok(n * 2205.0),
-
-        // pressure
-        ("Pa", "bar") => Ok(n / 100_000.0),
-        ("Pa", "psi") => Ok(n / 6895.0),
-
-        ("bar", "Pa") => Ok(n * 100_000.0),
-        ("bar", "psi") => Ok(n / 14.504),
-
-        ("psi", "Pa") => Ok(n * 6895.0),
-        ("psi", "bar") => Ok(n * 14.504),
-
-        // temperature
-        ("°C", "°F") => Ok((n * 9.0 / 5.0) + 32.0),
-        ("°C", "K") => Ok(n + 273.15),
-
-        ("°F", "°C") => Ok((n - 32.0) * 5.0 / 9.0),
-        ("°F", "K") => Ok((n - 32.0) * 5.0 / 9.0 - 273.15),
-
-        ("K", "°C") => Ok(n - 273.15),
-        ("K", "°F") => Ok((n - 273.15) * 9.0 / 5.0 + 32.0),
-        _ => currencies.convert(src_unit, dst_unit, n, range),
-    }
-}
-
-pub fn format(unit: &Unit, plural: bool) -> String {
-    let mut result = String::new();
-    let numerator = format_unit(&unit.0, plural);
-    result += &numerator;
-
-    if let Some(denom) = &unit.1 {
-        let denom = format_unit(denom, false);
-        result += " per";
-        result += &denom;
-    }
-
-    result
-}
-
-fn format_unit(unit: &str, plural: bool) -> String {
-    fn lowercase_first(s: &str) -> String {
-        let mut chars = s.chars();
-        match chars.next() {
-            Some(char) => char.to_lowercase().chain(chars).collect(),
-            None => String::new(),
-        }
-    }
-
-    let prefix = unit_prefix(unit).map(|x| x.0);
-    let unit = if prefix.is_some() { &unit[1..] } else { unit };
-
-    let mut result = " ".to_string();
-
-    if let Some(prefix) = prefix {
-        result.push_str(match prefix {
-            'm' => "Milli",
-            'c' => "Centi",
-            'd' => "Deci",
-            'h' => "Hecto",
-            'k' => "Kilo",
-            'M' => "Mega",
-            'G' => "Giga",
-            'T' => "Tera",
-            _ => unreachable!()
-        });
-    }
-
-    let unit_str = if plural {
-        match unit {
-            "ft" => "Feet",
-            "in" => "Inches",
-            "pa" => "Pascal",
-            "°C" => "Degrees Celsius",
-            "°F" => "Degrees Fahrenheit",
-            "K" => "Kelvin",
-            "psi" => "Pounds per square inch",
-
-            "m^2" => "Meters squared",
-            "mi^2" => "Miles squared",
-            "ft^2" => "Feet squared",
-            "in^2" => "Inches squared",
-            "yd^2" => "Yards squared",
-
-            "m^3" => "Meters cubed",
-            "mi^3" => "Miles cubed",
-            "ft^3" => "Feet cubed",
-            "in^3" => "Inches cubed",
-            "yd^3" => "Yards cubed",
-            _ => "",
-        }
-    } else { "" };
-
-    if unit_str.is_empty() {
-        let singular = match unit {
-            // length
-            "m" => "Meter",
-            "mi" => "Mile",
-            "ft" => "Foot",
-            "in" => "Inch",
-            "yd" => "Yard",
-            // area
-            "m^2" => "Meter squared",
-            "mi^2" => "Mile squared",
-            "ft^2" => "Foot squared",
-            "in^2" => "Inch squared",
-            "yd^2" => "Yard squared",
-            "a" => "Are",
-            // volume
-            "l" => "Liter",
-            "tsp" => "Teaspoon",
-            "tbsp" => "Tablespoon",
-            "floz" => "Fluid Ounce",
-            "cup" => "Cup",
-            "m^3" => "Meter cubed",
-            "mi^3" => "Mile cubed",
-            "ft^3" => "Foot cubed",
-            "in^3" => "Inch cubed",
-            "yd^3" => "Yard cubed",
-            // angle
-            "°" => "Degree",
-            "rad" => "Radian",
-            // time
-            "s" => "Second",
-            "min" => "Minute",
-            "h" => "Hour",
-            "d" => "Day",
-            "mo" => "Month",
-            "y" => "Year",
-            // mass
-            "g" => "Gram",
-            "lb" => "Pound",
-            "t" => "Tonne",
-            // pressure
-            "Pa" => "Pascal",
-            "bar" => "Bar",
-            "psi" => "Pound per square inch",
-            // temperature
-            "°C" => "Degree Celsius",
-            "°F" => "Degree Fahrenheit",
-            "K" => "Kelvin",
-            // misc
-            "cal" => "Calorie",
-            "b" => "Byte",
-            _ => ""
-        };
-
-        if is_currency(unit) {
-            if result.len() - 1 != 0 { result.push(' '); }
-            result += unit;
-        } else if !singular.is_empty() {
-            if prefix.is_some() {
-                result.push_str(lowercase_first(singular).as_str());
-            } else {
-                result.push_str(singular);
-            }
-
-            if plural {
-                result.push('s');
-            }
-        } else {
-            unreachable!()
-        }
-    } else if prefix.is_some() {
-        result.push_str(lowercase_first(unit_str).as_str());
-    } else {
-        result.push_str(unit_str);
-    }
-
-    result
 }

--- a/calculator/src/lib.rs
+++ b/calculator/src/lib.rs
@@ -18,7 +18,6 @@ use common::Result;
 use engine::Engine;
 use environment::{
     currencies::Currencies,
-    units::format as format_unit,
     Variable,
 };
 pub use environment::{Environment, Function};
@@ -241,7 +240,7 @@ impl<'a> Calculator<'a> {
 
                 let unit = result.unit.as_ref().map(|unit| {
                     if result.is_long_unit {
-                        format_unit(unit, result.result != 1.0)
+                        format!(" {}", unit.format(result.result != 1.0))
                     } else {
                         unit.to_string()
                     }

--- a/calculator/unit_data.txt
+++ b/calculator/unit_data.txt
@@ -1,8 +1,8 @@
-# this is a test
+# This defines unit conversion data. Based on it, build.rs generates src/environment/unit_conversion.rs.
 
 # syntax:
 #   comment: "#..."
-#   one way conversion: src (Long name [/ Plural Long name]) -> dst (Long name [/ Plural Long name]): x <*|/> <number> [| [n][p]]
+#   one way conversion: src (Long name [/ Plural Long name]) -> dst (Long name [/ Plural Long name]): x <*|/|+|-> <number> [| [n][p]]
 #   two way conversion: src (Long name [/ Plural Long name]) -> dst (Long name [/ Plural Long name]): <src->dst conversion expression> ; <dst->src conversion expression> [| p]
 
 # legend:
@@ -10,108 +10,112 @@
 #    p: powers => format: x <*|/|+|-> <number>. Unit can have powers. In that case, <number> is raised
 #                                               to that power before conversion.
 
+# unit definitions
+
+m: Meter, mi: Mile, ft: Foot / Feet, in: Inch / Inches, yd: Yard,
+l: Liter, tsp: Teaspoon, tbsp: Tablespoon, floz: Fluid Ounce, cup: Cup,
+°: Degree, rad: Radian,
+s: Second, min: Minute, h: Hour, d: Day, mo: Month, y: Year,
+g: Gram, lb: Pound, t: Tonne,
+Pa: Pascal / Pascal, bar: Bar, psi: Pound per square inch / Pounds per square inch,
+°C: Degree Celsius / Degrees Celsius, °F: Degree Fahrenheit / Degrees Fahrenheit,
+K: Kelvin / Kelvin
+cal: Calorie,
+b: Byte
+
+----
+
 # length
-m (Meter) -> mi (Mile): x / 1609.344    | np
+m->mi: x / 1609.344 | np
+m->ft: x * 3.281    | np
+m->in: x * 39.37    | np
+m->yd: x * 1.094    | np
 
-# --------------------------------------------
-# result after expansion
-m -> mi: x / 1609.344
-m^2 -> mi^2: x / 1609.344^2
-m^3 -> mi^3: x / 1609.344^3
-mi -> m: x * 1609.344
-mi^2 -> m^2: x * 1609.344^2
-mi^3 -> m^3: x * 1609.344^3
-# --------------------------------------------
+ft->mi: x / 5280.0  | np
+ft->in: x * 12.0    | np
+ft->yd: x / 3.0     | np
 
-m-> ft (Foot / Feet): x * 3.281         | np
-m -> in (Inch / Inches): x * 39.37      | np
-m -> yd (Yard): x * 1.094               | np
+mi->in: x * 63360.0 | np
+mi->yd: x * 1760.0  | np
 
-ft->mi: x / 5280    | np
-ft->in: x * 12      | np
-ft->yd: x / 3       | np
-
-mi->in: x * 63360   | np
-mi->yd: x * 1760    | np
-
-in->yd: x / 36      | np
+in->yd: x / 36.0    | np
 
 # volume
-l (Liter) -> tsp (Teaspoon): x * 202.9  | n
-l -> tbsp (Tablespoon): x * 67.628      | n
-l -> floz (Fluid Ounce): x * 33.814     | n
-l -> cup (Cup): x * 4.227               | n
-l -> m^3: x / 1000                      | n
-l -> mi^3: x / 4_168_000_000_000        | n
-l -> ft^3: x / 28.317                   | n
-l -> in^3: x * 61.024                   | n
-l -> yd^3: n / 764.6                    | n
+l->tsp: x * 202.9                   | n
+l->tbsp: x * 67.628                 | n
+l->floz: x * 33.814                 | n
+l->cup: x * 4.227                   | n
+l->m^3: x / 1000.0                  | n
+l->mi^3: x / 4_168_000_000_000.0    | n
+l->ft^3: x / 28.317                 | n
+l->in^3: x * 61.024                 | n
+l->yd^3: x / 764.6                  | n
 
-tsp -> tbsp: x / 3                      | n
-tsp -> floz: x / 6                      | n
-tsp -> cup: x / 48                      | n
-tsp -> m^3: x / 202_900                 | n
-tsp -> mi^3: x / 845_700_000_000_000    | n
-tsp -> ft^3: x / 5745                   | n
+tsp -> tbsp: x / 3.0                    | n
+tsp -> floz: x / 6.0                    | n
+tsp -> cup: x / 48.0                    | n
+tsp -> m^3: x / 202_900.0               | n
+tsp -> mi^3: x / 845_700_000_000_000.0  | n
+tsp -> ft^3: x / 5745.0                 | n
 tsp -> in^3: x / 3.325                  | n
-tsp -> yd^3: x / 155_100                | n
+tsp -> yd^3: x / 155_100.0              | n
 
-tbsp -> floz: x / 2                     | n
-tbsp -> cup: x / 16                     | n
-tbsp -> m^3: x / 67_630                 | n
-tbsp -> mi^3: x / 281_900_000_000_000   | n
-tbsp -> ft^3: x / 1915                  | n
+tbsp -> floz: x / 2.0                   | n
+tbsp -> cup: x / 16.0                   | n
+tbsp -> m^3: x / 67_630.0               | n
+tbsp -> mi^3: x / 281_900_000_000_000.0 | n
+tbsp -> ft^3: x / 1915.0                | n
 tbsp -> in^3: x / 1.108                 | n
-tbsp -> yd^3: x / 51_710                | n
+tbsp -> yd^3: x / 51_710.0              | n
 
-floz -> cup: x / 8                      | n
-floz -> m^3: x / 284_130                | n
-floz -> mi^3: x / 146_700_000_000_000   | n
+floz -> cup: x / 8.0                    | n
+floz -> m^3: x / 284_130.0              | n
+floz -> mi^3: x / 146_700_000_000_000.0 | n
 floz -> ft^3: x / 996.6                 | n
 floz -> in^3: x / 1.1734                | n
-floz -> yd^3: x / 25_850                | n
+floz -> yd^3: x / 25_850.0              | n
 
-cup -> m^3: x / 4227                | n
-cup -> mi^3: x / 17_620_000_000_000 | n
-cup -> ft^3: x / 119.7              | n
-cup -> in^3: x * 14.438             | n
-cup -> yd^3: x / 3232               | n
+cup -> m^3: x / 4227.0                  | n
+cup -> mi^3: x / 17_620_000_000_000.0   | n
+cup -> ft^3: x / 119.7                  | n
+cup -> in^3: x * 14.438                 | n
+cup -> yd^3: x / 3232.0                 | n
 
 # angle
-° (Degree) -> rad (Radian): x * PI / 180 ; x * 180 / PI
+°->rad: x * PI / 180.0 ; x * 180.0 / PI
 
 # time
-s (Second) -> min (Minute): x / 60  | n
-s -> h (Hour): x / 3600             | n
-s -> d (Day): x / 86_400            | n
-s -> mo (Month): x / 2_628_000      | n
-s -> y (Year): x / 31_540_000       | n
+s->min: x / 60.0        | n
+s->h: x / 3600.0        | n
+s->d: x / 86_400.0      | n
+s->mo: x / 2_628_000.0  | n
+s->y: x / 31_540_000.0  | n
 
-min -> h: x / 60        | n
-min -> d: x / 1440      | n
-min -> mo: x / 43_800   | n
-min -> y: x / 525_600   | n
+min->h: x / 60.0      | n
+min->d: x / 1440.0    | n
+min->mo: x / 43_800.0 | n
+min->y: x / 525_600.0 | n
 
-h -> d: x / 24      | n
-h -> mo: x / 730    | n
-h -> y: x / 8760    | n
+h->d: x / 24.0    | n
+h->mo: x / 730.0  | n
+h->y: x / 8760.0  | n
 
-d -> mo: x / 30.417 | n
-d -> y: x / 365     | n
+d->mo: x / 30.417 | n
+d->y: x / 365.0   | n
 
-mo -> y: x / 12 | n
+mo->y: x / 12.0 | n
 
 # mass
-g (Gram) -> lb (Pound): x / 453.59237   | n
-g -> t (Tonne): x / 1_000_000           | n
-lb -> t: x / 2205                       | n
+g->lb: x / 453.59237    | n
+g->t: x / 1_000_000.0   | n
+lb->t: x / 2205.0       | n
 
 # pressure
-Pa (Pascal / Pascal) -> bar (Bar): x / 100_000                          | n
-Pa -> psi (Pound per square inch / Pounds per square inch): x / 6895    | n
-bar -> psi: x / 14.504                                                  | n
+Pa->bar: x / 100_000.0  | n
+Pa->psi: x / 6895.0     | n
+bar->psi: x / 14.504    | n
 
 # temperature
-°C (Degree Celsius / Degrees Celsius) -> °F (Degree Fahrenheit / Degrees Fahrenheit): (x * 9 / 5) + 32 ; (x - 32) * 5 / 9
-°C -> K (Kelvin / Kelvin): n + 273.15   | n
-°F -> K: (x - 32) * 5 / 9 - 273.15 ; (x - 273.15) * 9 / 5 + 32
+°C->°F: (x * 9.0 / 5.0) + 32.0 ; (x - 32.0) * 5.0 / 9.0
+°C->K: x + 273.15   | n
+°F->K: (x - 32.0) * 5.0 / 9.0 - 273.15 ; (x - 273.15) * 9.0 / 5.0 + 32.0

--- a/calculator/unit_data.txt
+++ b/calculator/unit_data.txt
@@ -1,0 +1,117 @@
+# this is a test
+
+# syntax:
+#   comment: "#..."
+#   one way conversion: src (Long name [/ Plural Long name]) -> dst (Long name [/ Plural Long name]): x <*|/> <number> [| [n][p]]
+#   two way conversion: src (Long name [/ Plural Long name]) -> dst (Long name [/ Plural Long name]): <src->dst conversion expression> ; <dst->src conversion expression> [| p]
+
+# legend:
+#    n: normal => format: x <*|/|+|-> <number>. Inverse conversion with inverse operator (* <-> /, + <-> -)
+#    p: powers => format: x <*|/|+|-> <number>. Unit can have powers. In that case, <number> is raised
+#                                               to that power before conversion.
+
+# length
+m (Meter) -> mi (Mile): x / 1609.344    | np
+
+# --------------------------------------------
+# result after expansion
+m -> mi: x / 1609.344
+m^2 -> mi^2: x / 1609.344^2
+m^3 -> mi^3: x / 1609.344^3
+mi -> m: x * 1609.344
+mi^2 -> m^2: x * 1609.344^2
+mi^3 -> m^3: x * 1609.344^3
+# --------------------------------------------
+
+m-> ft (Foot / Feet): x * 3.281         | np
+m -> in (Inch / Inches): x * 39.37      | np
+m -> yd (Yard): x * 1.094               | np
+
+ft->mi: x / 5280    | np
+ft->in: x * 12      | np
+ft->yd: x / 3       | np
+
+mi->in: x * 63360   | np
+mi->yd: x * 1760    | np
+
+in->yd: x / 36      | np
+
+# volume
+l (Liter) -> tsp (Teaspoon): x * 202.9  | n
+l -> tbsp (Tablespoon): x * 67.628      | n
+l -> floz (Fluid Ounce): x * 33.814     | n
+l -> cup (Cup): x * 4.227               | n
+l -> m^3: x / 1000                      | n
+l -> mi^3: x / 4_168_000_000_000        | n
+l -> ft^3: x / 28.317                   | n
+l -> in^3: x * 61.024                   | n
+l -> yd^3: n / 764.6                    | n
+
+tsp -> tbsp: x / 3                      | n
+tsp -> floz: x / 6                      | n
+tsp -> cup: x / 48                      | n
+tsp -> m^3: x / 202_900                 | n
+tsp -> mi^3: x / 845_700_000_000_000    | n
+tsp -> ft^3: x / 5745                   | n
+tsp -> in^3: x / 3.325                  | n
+tsp -> yd^3: x / 155_100                | n
+
+tbsp -> floz: x / 2                     | n
+tbsp -> cup: x / 16                     | n
+tbsp -> m^3: x / 67_630                 | n
+tbsp -> mi^3: x / 281_900_000_000_000   | n
+tbsp -> ft^3: x / 1915                  | n
+tbsp -> in^3: x / 1.108                 | n
+tbsp -> yd^3: x / 51_710                | n
+
+floz -> cup: x / 8                      | n
+floz -> m^3: x / 284_130                | n
+floz -> mi^3: x / 146_700_000_000_000   | n
+floz -> ft^3: x / 996.6                 | n
+floz -> in^3: x / 1.1734                | n
+floz -> yd^3: x / 25_850                | n
+
+cup -> m^3: x / 4227                | n
+cup -> mi^3: x / 17_620_000_000_000 | n
+cup -> ft^3: x / 119.7              | n
+cup -> in^3: x * 14.438             | n
+cup -> yd^3: x / 3232               | n
+
+# angle
+° (Degree) -> rad (Radian): x * PI / 180 ; x * 180 / PI
+
+# time
+s (Second) -> min (Minute): x / 60  | n
+s -> h (Hour): x / 3600             | n
+s -> d (Day): x / 86_400            | n
+s -> mo (Month): x / 2_628_000      | n
+s -> y (Year): x / 31_540_000       | n
+
+min -> h: x / 60        | n
+min -> d: x / 1440      | n
+min -> mo: x / 43_800   | n
+min -> y: x / 525_600   | n
+
+h -> d: x / 24      | n
+h -> mo: x / 730    | n
+h -> y: x / 8760    | n
+
+d -> mo: x / 30.417 | n
+d -> y: x / 365     | n
+
+mo -> y: x / 12 | n
+
+# mass
+g (Gram) -> lb (Pound): x / 453.59237   | n
+g -> t (Tonne): x / 1_000_000           | n
+lb -> t: x / 2205                       | n
+
+# pressure
+Pa (Pascal / Pascal) -> bar (Bar): x / 100_000                          | n
+Pa -> psi (Pound per square inch / Pounds per square inch): x / 6895    | n
+bar -> psi: x / 14.504                                                  | n
+
+# temperature
+°C (Degree Celsius / Degrees Celsius) -> °F (Degree Fahrenheit / Degrees Fahrenheit): (x * 9 / 5) + 32 ; (x - 32) * 5 / 9
+°C -> K (Kelvin / Kelvin): n + 273.15   | n
+°F -> K: (x - 32) * 5 / 9 - 273.15 ; (x - 273.15) * 9 / 5 + 32


### PR DESCRIPTION
A unit conversion Rust file is now generated automatically from the `/calculator/unit_data.txt` file. This makes it way easier to maintain them since it is easier readable, as well as allowing anyone, even people who don't know Rust, to add units and their conversions.