### PR TITLE
Improve unit system

### DIFF
--- a/calculator/src/astgen/ast.rs
+++ b/calculator/src/astgen/ast.rs
@@ -11,11 +11,12 @@ use crate::{
     common::*,
     environment::{
         currencies::Currencies,
-        units::{convert, Unit},
+        units::convert,
     },
     Format,
 };
 use crate::astgen::objects::CalculatorObject;
+use crate::environment::units::Unit;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub enum BooleanOperator {

--- a/calculator/src/astgen/ast.rs
+++ b/calculator/src/astgen/ast.rs
@@ -7,14 +7,10 @@
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
 
-use crate::{
-    common::*,
-    environment::{
-        currencies::Currencies,
-        units::convert,
-    },
-    Format,
-};
+use crate::{common::*, environment::{
+    currencies::Currencies,
+    units::convert,
+}, error, Format};
 use crate::astgen::objects::CalculatorObject;
 use crate::environment::units::Unit;
 
@@ -202,13 +198,30 @@ impl AstNode {
         if rhs.unit.is_some() && self.unit.is_none() {
             self.unit = rhs.unit.clone();
         } else if rhs.unit.is_some() && rhs.unit != self.unit {
-            rhs_value = convert(
+            if let Ok(rhs) = convert(
                 rhs.unit.as_ref().unwrap(),
                 self.unit.as_ref().unwrap(),
                 rhs_value,
                 currencies,
                 &full_range,
-            )?;
+            ) {
+                rhs_value = rhs;
+            } else {
+                let rhs_unit = rhs.unit.take().unwrap();
+                let lhs_unit = self.unit.take().unwrap();
+                self.unit = Some(match op {
+                    Operator::Multiply => lhs_unit.push_unit(rhs_unit),
+                    Operator::Divide => {
+                        if let Unit::Fraction(rhs_num, rhs_denom) = rhs_unit {
+                            // Multiply by the inverse of the fraction
+                            lhs_unit.push_unit(Unit::Fraction(rhs_denom, rhs_num))
+                        } else {
+                            Unit::Fraction(Box::new(lhs_unit), Box::new(rhs_unit))
+                        }
+                    }
+                    _ => error!(UnknownConversion(rhs_unit.format(false, false), lhs_unit.format(false, false)): full_range),
+                });
+            }
         }
 
         match op {

--- a/calculator/src/astgen/objects.rs
+++ b/calculator/src/astgen/objects.rs
@@ -217,7 +217,7 @@ impl DateObject {
             unit.and_then(|unit| {
                 units::convert(
                     unit,
-                    &Unit::from("ns"),
+                    &Unit::Unit("ns".to_string()),
                     n,
                     &Currencies::none(),
                     &range,
@@ -252,7 +252,7 @@ impl DateObject {
                     let duration = self.date.signed_duration_since(object.date);
                     let days = duration.num_milliseconds() as f64 / 1000.0 / 60.0 / 60.0 / 24.0;
                     let mut result = AstNode::new(AstNodeData::Literal(days), self_range);
-                    result.unit = Some(Unit::from("d"));
+                    result.unit = Some(Unit::Unit("d".to_string()));
                     Ok(result)
                 }
                 _ => Err(ErrorType::InvalidSide.with(other.range.clone()))

--- a/calculator/src/astgen/objects.rs
+++ b/calculator/src/astgen/objects.rs
@@ -217,7 +217,7 @@ impl DateObject {
             unit.and_then(|unit| {
                 units::convert(
                     unit,
-                    &Unit::Unit("ns".to_string()),
+                    &Unit::from("ns"),
                     n,
                     &Currencies::none(),
                     &range,

--- a/calculator/src/astgen/parser.rs
+++ b/calculator/src/astgen/parser.rs
@@ -646,7 +646,7 @@ impl<'a> Parser<'a> {
                 return match denominator {
                     Ok((denom, denominator_range)) => {
                         Some(Ok((
-                            Unit(numerator, Some(denom)),
+                            Unit::Fraction(Box::new(Unit::Unit(numerator)), Box::new(Unit::Unit(denom))),
                             numerator_range.start..denominator_range.end
                         )))
                     }
@@ -657,7 +657,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Some(Ok((Unit(numerator, None), numerator_range)))
+        Some(Ok((Unit::Unit(numerator), numerator_range)))
     }
 
     fn accept_unit(&mut self) -> Option<Result<(String, Range<usize>)>> {
@@ -925,7 +925,7 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use crate::astgen::tokenizer::tokenize;
-    use crate::{Settings, Currencies, Environment, match_ast_node};
+    use crate::{Settings, Currencies, Environment};
 
     use super::*;
 

--- a/calculator/src/astgen/parser.rs
+++ b/calculator/src/astgen/parser.rs
@@ -696,13 +696,13 @@ impl<'a> Parser<'a> {
             match token.ty {
                 OpenBracket => 'blk: {
                     self.index += 1;
-                    let (units, range) = self.next_units(nesting_level + 1)?;
+                    let (mut units, range) = self.next_units(nesting_level + 1)?;
                     if units.is_empty() {
                         error!(ExpectedElements: token_range.start..range.end);
                     }
                     result_range.end = range.end;
 
-                    let unit = Unit::Product(units);
+                    let unit = if units.len() == 1 { units.remove(0) } else { Unit::Product(units) };
 
                     if let Some(numerator) = numerator.take() {
                         result.push(Unit::Fraction(Box::new(numerator), Box::new(unit)));
@@ -722,8 +722,8 @@ impl<'a> Parser<'a> {
                         error!(ExpectedUnit: token_range);
                     }
 
-                    return Ok((result, result_range))
-                },
+                    return Ok((result, result_range));
+                }
                 Identifier => 'blk: {
                     let Some(unit) = self.try_accept_single_unit() else {
                         error!(ExpectedUnit: token_range);

--- a/calculator/src/common.rs
+++ b/calculator/src/common.rs
@@ -67,6 +67,8 @@ pub enum ErrorType {
     ExpectedUnit,
     #[error("Unexpected unit")]
     UnexpectedUnit,
+    #[error("The units don't match")]
+    UnitsNotMatching,
     #[error("Expected text")]
     ExpectedElements,
     #[error("Expected end")]

--- a/calculator/src/engine.rs
+++ b/calculator/src/engine.rs
@@ -8,9 +8,10 @@ use std::fmt::{Display, Formatter};
 use std::mem::{replace, take};
 use std::ops::Range;
 
-use crate::{astgen::ast::{AstNode, AstNodeData, Operator}, astgen::tokenizer::TokenType, common::*, Context, Currencies, environment::{Environment, units::{convert as convert_units, Unit}, Variable}, match_ast_node, Settings};
+use crate::{astgen::ast::{AstNode, AstNodeData, Operator}, astgen::tokenizer::TokenType, common::*, Context, Currencies, environment::{Environment, units::convert as convert_units, Variable}, match_ast_node, Settings};
 use crate::astgen::ast::BooleanOperator;
 use crate::astgen::objects::CalculatorObject;
+use crate::environment::units::Unit;
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Format { Decimal, Hex, Binary, Scientific }

--- a/calculator/src/engine.rs
+++ b/calculator/src/engine.rs
@@ -123,7 +123,11 @@ impl Value {
 
     pub fn format(&self, settings: &Settings, use_thousands_separator: bool) -> String {
         match self {
-            Value::Number(number) => format!("{}{}", number.format.format(number.number, use_thousands_separator), number.unit_string()),
+            Value::Number(number) => {
+                let mut result = number.format.format(number.number, use_thousands_separator);
+                if !matches!(number.unit, Some(Unit::Unit(_))) || number.is_long_unit { result.push(' '); }
+                result + &number.unit_string()
+            },
             Value::Object(object) => object.to_string(settings),
         }
     }

--- a/calculator/src/environment/mod.rs
+++ b/calculator/src/environment/mod.rs
@@ -192,12 +192,11 @@ impl Environment {
         let args = arg_results.iter().map(|r| r.number).collect::<Vec<_>>();
 
         let as_radians = |i: usize| {
-            println!("TODO: as_radians");
-            // if let Some(unit) = &arg_results[i].unit {
-            //     if unit.0 == "°" {
-            //         return args[i].to_radians();
-            //     }
-            // }
+            if let Some(Unit::Unit(str)) = &arg_results[i].unit {
+                if str == "°" {
+                    return args[i].to_radians();
+                }
+            }
             args[i]
         };
 

--- a/calculator/src/environment/mod.rs
+++ b/calculator/src/environment/mod.rs
@@ -8,8 +8,7 @@ use std::f64::consts::{E, PI, TAU};
 
 use crate::{astgen::ast::AstNode, common::ErrorType, Context, Engine};
 use crate::engine::{NumberValue, Value};
-
-use self::units::Unit;
+use crate::environment::units::Unit;
 
 pub mod units;
 pub mod currencies;
@@ -193,11 +192,12 @@ impl Environment {
         let args = arg_results.iter().map(|r| r.number).collect::<Vec<_>>();
 
         let as_radians = |i: usize| {
-            if let Some(unit) = &arg_results[i].unit {
-                if unit.0 == "°" {
-                    return args[i].to_radians();
-                }
-            }
+            println!("TODO: as_radians");
+            // if let Some(unit) = &arg_results[i].unit {
+            //     if unit.0 == "°" {
+            //         return args[i].to_radians();
+            //     }
+            // }
             args[i]
         };
 

--- a/calculator/src/environment/units.rs
+++ b/calculator/src/environment/units.rs
@@ -41,8 +41,8 @@ impl std::fmt::Display for Unit {
             Self::Product(units) => {
                 write!(f, "(")?;
                 for (i, unit) in units.iter().enumerate() {
-                    if i != units.len() - 1 { write!(f, "*")?; }
                     write!(f, "{unit}")?;
+                    if i != units.len() - 1 { write!(f, "*")?; }
                 }
                 write!(f, ")")
             }

--- a/calculator/src/environment/units.rs
+++ b/calculator/src/environment/units.rs
@@ -16,6 +16,25 @@ pub enum Unit {
 }
 
 impl Unit {
+    pub fn push_unit(self, other: Unit) -> Unit {
+        match self {
+            unit @ Self::Unit(_) => Unit::Product(vec![unit, other]),
+            Self::Product(mut units) => {
+                units.push(other);
+                Unit::Product(units)
+            }
+            Self::Fraction(num, denom) => {
+                if let Self::Fraction(other_num, other_denom) = other {
+                    let num = num.push_unit(*other_num);
+                    let denom = denom.push_unit(*other_denom);
+                    Unit::Fraction(Box::new(num), Box::new(denom))
+                } else {
+                    Unit::Fraction(Box::new(num.push_unit(other)), denom)
+                }
+            }
+        }
+    }
+
     pub fn format(&self, full_unit: bool, plural: bool) -> String {
         if !full_unit {
             match self {

--- a/calculator/src/environment/units.rs
+++ b/calculator/src/environment/units.rs
@@ -8,14 +8,6 @@ use std::ops::Range;
 
 use crate::{common::{ErrorType, Result}, environment::currencies::{Currencies, is_currency}, environment::unit_conversion::{convert_units, format_unit, UNITS}, error};
 
-/// A struct representing a unit, holding a numerator and an optional denominator unit.
-///
-/// e.g. for `"km/h"`:
-/// - numerator (0): `"km"`
-/// - denominator (1): `"h"`
-#[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
-pub struct OldUnit(pub String, pub Option<String>);
-
 #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Unit {
     Product(Vec<Unit>),
@@ -97,40 +89,6 @@ impl From<&str> for Unit {
 impl std::fmt::Display for Unit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.format(false, false))
-    }
-}
-
-impl OldUnit {
-    pub fn format(&self, full_unit: bool, plural: bool) -> String {
-        if !full_unit {
-            self.to_string()
-        } else {
-            let mut result = " ".to_string();
-            let numerator = format_unit(&self.0, plural);
-            result += &numerator;
-
-            if let Some(denom) = &self.1 {
-                let denom = format_unit(denom, false);
-                result += " per ";
-                result += &denom;
-            }
-
-            result
-        }
-    }
-}
-
-impl From<&str> for OldUnit {
-    fn from(s: &str) -> Self { OldUnit(s.to_owned(), None) }
-}
-
-impl std::fmt::Display for OldUnit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)?;
-        if let Some(denom) = &self.1 {
-            write!(f, "/{denom}")?;
-        }
-        Ok(())
     }
 }
 

--- a/calculator/src/lib.rs
+++ b/calculator/src/lib.rs
@@ -257,9 +257,6 @@ impl<'a> Calculator<'a> {
                 let result = Engine::evaluate(ast, self.context())?;
                 self.env_mut().set_ans_variable(Variable(result.clone()));
 
-                // let unit = result.unit.as_ref().map(|unit| {
-                //     unit.format(result.is_long_unit, result.result != 1.0)
-                // });
                 Ok(CalculatorResult::value(result, color_segments))
             }
             ParserResult::BooleanExpression { lhs, rhs, operator } => {

--- a/calculator/src/lib.rs
+++ b/calculator/src/lib.rs
@@ -276,10 +276,6 @@ impl<'a> Calculator<'a> {
                 match ast {
                     Some(ast) => {
                         let res = Engine::evaluate(ast, self.context())?;
-                        // let unit = res.unit.as_ref().map(|unit| {
-                        //     unit.format(res.is_long_unit, res.result != 1.0)
-                        // });
-
                         self.env_mut().set_variable(&name, Variable(res.clone())).unwrap();
                         Ok(CalculatorResult::value(res, color_segments))
                     }

--- a/calculator/src/lib.rs
+++ b/calculator/src/lib.rs
@@ -340,6 +340,9 @@ impl<'a> Calculator<'a> {
 
         let tokens = tokenize(line)?;
 
+        let mut is_in_square_brackets = false;
+        let mut is_in_object = false;
+
         let mut new_line = String::new();
         for (i, token) in tokens.iter().enumerate() {
             let text = &token.text;
@@ -388,8 +391,21 @@ impl<'a> Calculator<'a> {
                     }
                 }
 
-                if (i != 0 && token.ty.is_literal() && tokens[i - 1].ty == Identifier) || (token.ty == OpenSquareBracket && tokens[i - 1].ty != ObjectArgs) {
+                if (i != 0 && token.ty.is_literal() && tokens[i - 1].ty == Identifier) ||
+                    (token.ty == OpenSquareBracket && tokens[i - 1].ty != ObjectArgs && is_in_object) {
                     new_line.push(' ');
+                }
+
+                if token.ty == OpenSquareBracket {
+                    is_in_square_brackets = true;
+                } else if token.ty == CloseSquareBracket {
+                    is_in_square_brackets = false;
+                }
+
+                if token.ty == OpenCurlyBracket {
+                    is_in_object = true;
+                } else if token.ty == CloseCurlyBracket {
+                    is_in_object = false;
                 }
 
                 new_line += &text;
@@ -414,7 +430,7 @@ impl<'a> Calculator<'a> {
                     }
                 }
                 // Format complex units without spaces (e.g. "km/h")
-                else if token.ty == Divide {
+                else if token.ty == Divide || token.ty == Multiply {
                     let is_prev_ident_and_unit = tokens.get(i - 1)
                         .map(|t| t.ty == Identifier && is_unit_with_prefix(&t.text))
                         .unwrap_or(false);
@@ -429,11 +445,11 @@ impl<'a> Calculator<'a> {
 
                 if !(token.ty.is_format() && tokens.get(i.saturating_sub(1))
                     .map_or(false, |t| t.ty == In)) &&
-                    token.ty != Exponentiation {
+                    token.ty != Exponentiation && !is_in_square_brackets {
                     new_line.push(' ');
                 }
                 new_line += text;
-                if i != tokens.len() - 1 && token.ty != Exponentiation {
+                if i != tokens.len() - 1 && token.ty != Exponentiation && !is_in_square_brackets {
                     new_line.push(' ');
                 }
             } else if token.ty == Comma {
@@ -441,7 +457,7 @@ impl<'a> Calculator<'a> {
                 if i != tokens.len() - 1 {
                     new_line.push(' ');
                 }
-            } else if token.ty == OpenSquareBracket {} else if token.ty == ObjectArgs {
+            } else if token.ty == ObjectArgs {
                 if tokens.get(i - 1).map(|t| t.ty == Identifier).unwrap_or_default() {
                     new_line.push(' ');
                 }


### PR DESCRIPTION
The unit system now supports complex units using `[]`, meaning "products" and "fractions" are much more extensive. In addition, units can also be "combined" when multiplying or dividing by a number whose unit cannot be converted into the LHS's unit. The units can still be converted between one another.